### PR TITLE
fix: fix test of purchase schemas to generate randint >= 1

### DIFF
--- a/app/tests/schemas/test_purchase.py
+++ b/app/tests/schemas/test_purchase.py
@@ -37,7 +37,7 @@ def test_purchase_schema_if_cashback_percent_is_not_passed_it_must_be_calculated
 def test_purchase_schema_if_cashback_percent_is_passed_it_must_returned(
     random_purchase_dict: Dict[str, Any]
 ):
-    expected = random.randint(0, 20)
+    expected = random.randint(1, 20)
     purchase_schema = schemas.Purchase(
         **random_purchase_dict, cashback_percent=expected
     )


### PR DESCRIPTION
fix test to generate randint >= 1 because if value is 0  must calculate the real cashback percent too